### PR TITLE
Explode `Connection:` header to find `Update`. Fixes #14

### DIFF
--- a/src/Handshake/RequestVerifier.php
+++ b/src/Handshake/RequestVerifier.php
@@ -92,9 +92,18 @@ class RequestVerifier {
      * @return bool
      */
     public function verifyConnection(array $connectionHeader) {
-        return count(array_filter($connectionHeader, function ($x) {
-            return 'upgrade' === strtolower($x);
-        })) > 0;
+        foreach ($connectionHeader as $l) {
+            $upgrades = array_filter(
+                array_map('trim', array_map('strtolower', explode(',', $l))),
+                function ($x) {
+                    return 'upgrade' === $x;
+                }
+            );
+            if (count($upgrades) > 0) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/tests/unit/Handshake/RequestVerifierTest.php
+++ b/tests/unit/Handshake/RequestVerifierTest.php
@@ -113,6 +113,11 @@ class RequestVerifierTest extends \PHPUnit_Framework_TestCase {
             array(true,  ['keep-alive', 'Upgrade']),
             array(true,  ['Upgrade', 'keep-alive']),
             array(true,  ['keep-alive', 'Upgrade', 'something']),
+            // as seen in Firefox 47.0.1 - see https://github.com/ratchetphp/RFC6455/issues/14
+            array(true,  ['keep-alive, Upgrade']),
+            array(true,  ['Upgrade, keep-alive']),
+            array(true,  ['keep-alive, Upgrade, something']),
+            array(true,  ['keep-alive, Upgrade', 'something']),
             array(false, ['']),
             array(false, [])
         );


### PR DESCRIPTION
Alternative implementation to #15 with tests. Fixes #14. 
