### PR TITLE
Correct Responses in ServerNegotiator add tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ before_script:
     - sh tests/ab/run_ab_tests.sh
 
 script:
-    - phpunit
+    - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     },
     "require-dev": {
         "react/http": "^0.4.1",
-        "react/socket-client": "^0.4.3"
+        "react/socket-client": "^0.4.3",
+        "phpunit/phpunit": "5.7"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,6 @@
     "require-dev": {
         "react/http": "^0.4.1",
         "react/socket-client": "^0.4.3",
-        "phpunit/phpunit": "5.7"
+        "phpunit/phpunit": "4.8.*"
     }
 }

--- a/src/Handshake/ServerNegotiator.php
+++ b/src/Handshake/ServerNegotiator.php
@@ -62,13 +62,7 @@ class ServerNegotiator implements NegotiatorInterface {
             'Sec-WebSocket-Protocol' => implode(', ', $this->_supportedSubProtocols)
         ];
         if (true !== $this->verifier->verifyUpgradeRequest($request->getHeader('Upgrade'))) {
-            return new Response(
-                426,
-                $upgradeSuggestion,
-                null,
-                '1.1',
-                'Upgrade header MUST be provided'
-            );
+            return new Response(426, $upgradeSuggestion, null, '1.1', 'Upgrade header MUST be provided');
         }
 
         if (true !== $this->verifier->verifyConnection($request->getHeader('Connection'))) {
@@ -80,12 +74,6 @@ class ServerNegotiator implements NegotiatorInterface {
         }
 
         if (true !== $this->verifier->verifyVersion($request->getHeader('Sec-WebSocket-Version'))) {
-            /*
-             * https://tools.ietf.org/html/rfc7230#section-6.7
-             * A server that sends a 426 (Upgrade Required) response MUST send an
-             * Upgrade header field to indicate the acceptable protocols, in order
-             * of descending preference
-             */
             return new Response(426, $upgradeSuggestion);
         }
 
@@ -99,7 +87,7 @@ class ServerNegotiator implements NegotiatorInterface {
             }, null);
 
             if ($this->_strictSubProtocols && null === $match) {
-                return new Response(426, $upgradeSuggestion);
+                return new Response(426, $upgradeSuggestion, null, '1.1', 'No Sec-WebSocket-Protocols requested supported');
             }
 
             if (null !== $match) {

--- a/src/Handshake/ServerNegotiator.php
+++ b/src/Handshake/ServerNegotiator.php
@@ -58,9 +58,11 @@ class ServerNegotiator implements NegotiatorInterface {
         $upgradeSuggestion = [
             'Connection'             => 'Upgrade',
             'Upgrade'                => 'websocket',
-            'Sec-WebSocket-Version'  => $this->getVersionNumber(),
-            'Sec-WebSocket-Protocol' => implode(', ', $this->_supportedSubProtocols)
+            'Sec-WebSocket-Version'  => $this->getVersionNumber()
         ];
+        if (count($this->_supportedSubProtocols) > 0) {
+            $upgradeSuggestion['Sec-WebSocket-Protocol'] = implode(', ', $this->_supportedSubProtocols);
+        }
         if (true !== $this->verifier->verifyUpgradeRequest($request->getHeader('Upgrade'))) {
             return new Response(426, $upgradeSuggestion, null, '1.1', 'Upgrade header MUST be provided');
         }

--- a/src/Handshake/ServerNegotiator.php
+++ b/src/Handshake/ServerNegotiator.php
@@ -13,15 +13,12 @@ class ServerNegotiator implements NegotiatorInterface {
      */
     private $verifier;
 
-    private $_supportedSubProtocols;
+    private $_supportedSubProtocols = [];
 
-    private $_strictSubProtocols;
+    private $_strictSubProtocols = false;
 
-    public function __construct(RequestVerifier $requestVerifier, array $supportedSubProtocols = [], $strictSubProtocol = false) {
+    public function __construct(RequestVerifier $requestVerifier) {
         $this->verifier = $requestVerifier;
-
-        $this->_supportedSubProtocols = $supportedSubProtocols;
-        $this->_strictSubProtocols = $strictSubProtocol;
     }
 
     /**
@@ -130,7 +127,6 @@ class ServerNegotiator implements NegotiatorInterface {
 
     /**
      * @param array $protocols
-     * @deprecated
      */
     function setSupportedSubProtocols(array $protocols) {
         $this->_supportedSubProtocols = array_flip($protocols);
@@ -143,7 +139,6 @@ class ServerNegotiator implements NegotiatorInterface {
      * @todo Consider extending this interface and moving this there.
      *       The spec does says the server can fail for this reason, but
      * it is not a requirement. This is an implementation detail.
-     * @deprecated
      */
     function setStrictSubProtocolCheck($enable) {
         $this->_strictSubProtocols = (boolean)$enable;

--- a/tests/unit/Handshake/ServerNegotiatorTest.php
+++ b/tests/unit/Handshake/ServerNegotiatorTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Ratchet\RFC6455\Test\Unit\Handshake;
+
+use function GuzzleHttp\Psr7\parse_request;
+use Ratchet\RFC6455\Handshake\RequestVerifier;
+use Ratchet\RFC6455\Handshake\ServerNegotiator;
+
+class ServerNegotiatorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testNoUpgradeRequested() {
+        $negotiator = new ServerNegotiator(new RequestVerifier());
+
+        $requestText = 'GET / HTTP/1.1
+Host: 127.0.0.1:6789
+Connection: keep-alive
+Pragma: no-cache
+Cache-Control: no-cache
+Upgrade-Insecure-Requests: 1
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36
+Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+Accept-Encoding: gzip, deflate, sdch, br
+Accept-Language: en-US,en;q=0.8';
+
+        $request = parse_request($requestText);
+
+        $response = $negotiator->handshake($request);
+
+        $this->assertEquals('1.1', $response->getProtocolVersion());
+        $this->assertEquals(426, $response->getStatusCode());
+        $this->assertEquals('Upgrade header MUST be provided', $response->getReasonPhrase());
+        $this->assertEquals('Upgrade', $response->getHeaderLine('Connection'));
+        $this->assertEquals('websocket', $response->getHeaderLine('Upgrade'));
+        $this->assertEquals('13', $response->getHeaderLine('Sec-WebSocket-Version'));
+    }
+
+    public function testNoConnectionUpgradeRequested() {
+        $negotiator = new ServerNegotiator(new RequestVerifier());
+
+        $requestText = 'GET / HTTP/1.1
+Host: 127.0.0.1:6789
+Connection: keep-alive
+Pragma: no-cache
+Cache-Control: no-cache
+Upgrade: websocket
+Upgrade-Insecure-Requests: 1
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36
+Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+Accept-Encoding: gzip, deflate, sdch, br
+Accept-Language: en-US,en;q=0.8';
+
+        $request = parse_request($requestText);
+
+        $response = $negotiator->handshake($request);
+
+        $this->assertEquals('1.1', $response->getProtocolVersion());
+        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertEquals('Connection Upgrade MUST be requested', $response->getReasonPhrase());
+    }
+
+    public function testInvalidSecWebsocketKey() {
+        $negotiator = new ServerNegotiator(new RequestVerifier());
+
+        $requestText = 'GET / HTTP/1.1
+Host: 127.0.0.1:6789
+Connection: Upgrade
+Pragma: no-cache
+Cache-Control: no-cache
+Upgrade: websocket
+Sec-WebSocket-Key: 12345
+Upgrade-Insecure-Requests: 1
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36
+Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+Accept-Encoding: gzip, deflate, sdch, br
+Accept-Language: en-US,en;q=0.8';
+
+        $request = parse_request($requestText);
+
+        $response = $negotiator->handshake($request);
+
+        $this->assertEquals('1.1', $response->getProtocolVersion());
+        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertEquals('Invalid Sec-WebSocket-Key', $response->getReasonPhrase());
+    }
+
+    public function testInvalidSecWebsocketVersion() {
+        $negotiator = new ServerNegotiator(new RequestVerifier());
+
+        $requestText = 'GET / HTTP/1.1
+Host: 127.0.0.1:6789
+Connection: Upgrade
+Pragma: no-cache
+Cache-Control: no-cache
+Upgrade: websocket
+Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
+Upgrade-Insecure-Requests: 1
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36
+Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+Accept-Encoding: gzip, deflate, sdch, br
+Accept-Language: en-US,en;q=0.8';
+
+        $request = parse_request($requestText);
+
+        $response = $negotiator->handshake($request);
+
+        $this->assertEquals('1.1', $response->getProtocolVersion());
+        $this->assertEquals(426, $response->getStatusCode());
+        $this->assertEquals('Upgrade Required', $response->getReasonPhrase());
+        $this->assertEquals('Upgrade', $response->getHeaderLine('Connection'));
+        $this->assertEquals('websocket', $response->getHeaderLine('Upgrade'));
+        $this->assertEquals('13', $response->getHeaderLine('Sec-WebSocket-Version'));
+    }
+
+    public function testBadSubprotocolResponse() {
+        $negotiator = new ServerNegotiator(new RequestVerifier(), [], true);
+
+        $requestText = 'GET / HTTP/1.1
+Host: 127.0.0.1:6789
+Connection: Upgrade
+Pragma: no-cache
+Cache-Control: no-cache
+Upgrade: websocket
+Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
+Sec-WebSocket-Version: 13
+Sec-WebSocket-Protocol: someprotocol
+Upgrade-Insecure-Requests: 1
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36
+Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+Accept-Encoding: gzip, deflate, sdch, br
+Accept-Language: en-US,en;q=0.8';
+
+        $request = parse_request($requestText);
+
+        $response = $negotiator->handshake($request);
+
+        $this->assertEquals('1.1', $response->getProtocolVersion());
+        $this->assertEquals(426, $response->getStatusCode());
+        $this->assertEquals('Upgrade Required', $response->getReasonPhrase());
+        $this->assertEquals('Upgrade', $response->getHeaderLine('Connection'));
+        $this->assertEquals('websocket', $response->getHeaderLine('Upgrade'));
+        $this->assertEquals('13', $response->getHeaderLine('Sec-WebSocket-Version'));
+    }
+}

--- a/tests/unit/Handshake/ServerNegotiatorTest.php
+++ b/tests/unit/Handshake/ServerNegotiatorTest.php
@@ -111,7 +111,9 @@ Accept-Language: en-US,en;q=0.8';
     }
 
     public function testBadSubprotocolResponse() {
-        $negotiator = new ServerNegotiator(new RequestVerifier(), [], true);
+        $negotiator = new ServerNegotiator(new RequestVerifier());
+        $negotiator->setStrictSubProtocolCheck(true);
+        $negotiator->setSupportedSubProtocols([]);
 
         $requestText = 'GET / HTTP/1.1
 Host: 127.0.0.1:6789

--- a/tests/unit/Handshake/ServerNegotiatorTest.php
+++ b/tests/unit/Handshake/ServerNegotiatorTest.php
@@ -136,7 +136,7 @@ Accept-Language: en-US,en;q=0.8';
 
         $this->assertEquals('1.1', $response->getProtocolVersion());
         $this->assertEquals(426, $response->getStatusCode());
-        $this->assertEquals('Upgrade Required', $response->getReasonPhrase());
+        $this->assertEquals('No Sec-WebSocket-Protocols requested supported', $response->getReasonPhrase());
         $this->assertEquals('Upgrade', $response->getHeaderLine('Connection'));
         $this->assertEquals('websocket', $response->getHeaderLine('Upgrade'));
         $this->assertEquals('13', $response->getHeaderLine('Sec-WebSocket-Version'));

--- a/tests/unit/Handshake/ServerNegotiatorTest.php
+++ b/tests/unit/Handshake/ServerNegotiatorTest.php
@@ -2,7 +2,6 @@
 
 namespace Ratchet\RFC6455\Test\Unit\Handshake;
 
-use function GuzzleHttp\Psr7\parse_request;
 use Ratchet\RFC6455\Handshake\RequestVerifier;
 use Ratchet\RFC6455\Handshake\ServerNegotiator;
 
@@ -22,7 +21,7 @@ Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0
 Accept-Encoding: gzip, deflate, sdch, br
 Accept-Language: en-US,en;q=0.8';
 
-        $request = parse_request($requestText);
+        $request = \GuzzleHttp\Psr7\parse_request($requestText);
 
         $response = $negotiator->handshake($request);
 
@@ -49,7 +48,7 @@ Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0
 Accept-Encoding: gzip, deflate, sdch, br
 Accept-Language: en-US,en;q=0.8';
 
-        $request = parse_request($requestText);
+        $request = \GuzzleHttp\Psr7\parse_request($requestText);
 
         $response = $negotiator->handshake($request);
 
@@ -74,7 +73,7 @@ Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0
 Accept-Encoding: gzip, deflate, sdch, br
 Accept-Language: en-US,en;q=0.8';
 
-        $request = parse_request($requestText);
+        $request = \GuzzleHttp\Psr7\parse_request($requestText);
 
         $response = $negotiator->handshake($request);
 
@@ -99,7 +98,7 @@ Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0
 Accept-Encoding: gzip, deflate, sdch, br
 Accept-Language: en-US,en;q=0.8';
 
-        $request = parse_request($requestText);
+        $request = \GuzzleHttp\Psr7\parse_request($requestText);
 
         $response = $negotiator->handshake($request);
 
@@ -129,7 +128,7 @@ Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0
 Accept-Encoding: gzip, deflate, sdch, br
 Accept-Language: en-US,en;q=0.8';
 
-        $request = parse_request($requestText);
+        $request = \GuzzleHttp\Psr7\parse_request($requestText);
 
         $response = $negotiator->handshake($request);
 


### PR DESCRIPTION
Some responses in `ServerNegotiator::handshake` had the protocol version and body parameters reversed.

I also added more information to the 426 responses per HTTP spec.

I also suggest deprecating the setters in `ServerNegotiator` and adding the information to the constructor.

A dev dependency for phpunit 5.7 was added which makes php 5.5 and 5.4 fail. I can further downgrade phpunit to get those passing that support is important.