### PR TITLE
Replaced isset with in_array 

### DIFF
--- a/src/Handshake/ServerNegotiator.php
+++ b/src/Handshake/ServerNegotiator.php
@@ -85,7 +85,7 @@ class ServerNegotiator implements NegotiatorInterface {
             $subProtocols = array_map('trim', explode(',', implode(',', $subProtocols)));
 
             $match = array_reduce($subProtocols, function($accumulator, $protocol) {
-                return $accumulator ?: (isset($this->_supportedSubProtocols[$protocol]) ? $protocol : null);
+                return $accumulator ?: (in_array($protocol, $this->_supportedSubProtocols) ? $protocol : null);
             }, null);
 
             if ($this->_strictSubProtocols && null === $match) {


### PR DESCRIPTION
It appears that in PHP7 isset does not express the same behaviour as under PHP5;
hence the check for supported protocols returns FALSE every round (most likely due to the fact the 
array is not an indexed array per se).
in_array is more robust in that sense, and is available since PHP4.