### PR TITLE
Suggest correct subprotocol when subprotocol mismatch

### DIFF
--- a/src/Handshake/ServerNegotiator.php
+++ b/src/Handshake/ServerNegotiator.php
@@ -61,7 +61,7 @@ class ServerNegotiator implements NegotiatorInterface {
             'Sec-WebSocket-Version'  => $this->getVersionNumber()
         ];
         if (count($this->_supportedSubProtocols) > 0) {
-            $upgradeSuggestion['Sec-WebSocket-Protocol'] = implode(', ', $this->_supportedSubProtocols);
+            $upgradeSuggestion['Sec-WebSocket-Protocol'] = implode(', ', array_keys($this->_supportedSubProtocols));
         }
         if (true !== $this->verifier->verifyUpgradeRequest($request->getHeader('Upgrade'))) {
             return new Response(426, $upgradeSuggestion, null, '1.1', 'Upgrade header MUST be provided');

--- a/tests/unit/Handshake/ServerNegotiatorTest.php
+++ b/tests/unit/Handshake/ServerNegotiatorTest.php
@@ -172,4 +172,34 @@ Accept-Language: en-US,en;q=0.8';
         $this->assertEquals('websocket', $response->getHeaderLine('Upgrade'));
         $this->assertFalse($response->hasHeader('Sec-WebSocket-Protocol'));
     }
+
+    public function testSuggestsAppropriateSubprotocol()
+    {
+        $negotiator = new ServerNegotiator(new RequestVerifier());
+        $negotiator->setStrictSubProtocolCheck(true);
+        $negotiator->setSupportedSubProtocols(['someproto']);
+
+        $requestText = 'GET / HTTP/1.1
+Host: localhost:8080
+Connection: Upgrade
+Upgrade: websocket
+Sec-WebSocket-Version: 13
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36
+Accept-Encoding: gzip, deflate, br
+Accept-Language: en-US,en;q=0.9
+Sec-WebSocket-Key: HGt8eQax7nAOlXUw0/asPQ==
+Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits
+
+';
+
+        $request = \GuzzleHttp\Psr7\parse_request($requestText);
+
+        $response = $negotiator->handshake($request);
+
+        $this->assertEquals('1.1', $response->getProtocolVersion());
+        $this->assertEquals(426, $response->getStatusCode());
+        $this->assertEquals('Upgrade', $response->getHeaderLine('Connection'));
+        $this->assertEquals('websocket', $response->getHeaderLine('Upgrade'));
+        $this->assertEquals('someproto', $response->getHeaderLine('Sec-WebSocket-Protocol'));
+    }
 }


### PR DESCRIPTION
Fixes #24 

I could not find this in the RFC, but it is better than suggesting `0` when things don't work out.