### PR TITLE
Fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ php:
     - 7.0
     - 7.1
     - 7.2
-    - hhvm
 
 before_install:
     - export PATH=$HOME/.local/bin:$PATH

--- a/tests/unit/Handshake/ServerNegotiatorTest.php
+++ b/tests/unit/Handshake/ServerNegotiatorTest.php
@@ -19,7 +19,9 @@ Upgrade-Insecure-Requests: 1
 User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36
 Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
 Accept-Encoding: gzip, deflate, sdch, br
-Accept-Language: en-US,en;q=0.8';
+Accept-Language: en-US,en;q=0.8
+
+';
 
         $request = \GuzzleHttp\Psr7\parse_request($requestText);
 
@@ -46,7 +48,9 @@ Upgrade-Insecure-Requests: 1
 User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36
 Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
 Accept-Encoding: gzip, deflate, sdch, br
-Accept-Language: en-US,en;q=0.8';
+Accept-Language: en-US,en;q=0.8
+
+';
 
         $request = \GuzzleHttp\Psr7\parse_request($requestText);
 
@@ -71,7 +75,9 @@ Upgrade-Insecure-Requests: 1
 User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36
 Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
 Accept-Encoding: gzip, deflate, sdch, br
-Accept-Language: en-US,en;q=0.8';
+Accept-Language: en-US,en;q=0.8
+
+';
 
         $request = \GuzzleHttp\Psr7\parse_request($requestText);
 
@@ -96,7 +102,9 @@ Upgrade-Insecure-Requests: 1
 User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36
 Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
 Accept-Encoding: gzip, deflate, sdch, br
-Accept-Language: en-US,en;q=0.8';
+Accept-Language: en-US,en;q=0.8
+
+';
 
         $request = \GuzzleHttp\Psr7\parse_request($requestText);
 
@@ -128,7 +136,9 @@ Upgrade-Insecure-Requests: 1
 User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36
 Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
 Accept-Encoding: gzip, deflate, sdch, br
-Accept-Language: en-US,en;q=0.8';
+Accept-Language: en-US,en;q=0.8
+
+';
 
         $request = \GuzzleHttp\Psr7\parse_request($requestText);
 
@@ -160,7 +170,9 @@ Upgrade-Insecure-Requests: 1
 User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36
 Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
 Accept-Encoding: gzip, deflate, sdch, br
-Accept-Language: en-US,en;q=0.8';
+Accept-Language: en-US,en;q=0.8
+
+';
 
         $request = \GuzzleHttp\Psr7\parse_request($requestText);
 


### PR DESCRIPTION
Guzzle appears to have made a backwards compatibility break between minor versions. Passing just an HTTP header to `parse_request` without ending delimiters now throws an exception. 