### PR TITLE
Update development deps and speed up frame processing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: php
 
 php:
-    - 5.4
-    - 5.5
     - 5.6
     - 7.0
     - 7.1
     - 7.2
+    - 7.3
+    - 7.4
 
 before_install:
     - export PATH=$HOME/.local/bin:$PATH

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,7 @@
         "guzzlehttp/psr7": "^1.0"
     },
     "require-dev": {
-        "react/http": "^0.4.1",
-        "react/socket-client": "^0.4.3",
-        "phpunit/phpunit": "4.8.*"
+        "phpunit/phpunit": "4.8.*",
+        "react/socket": "^1.3"
     }
 }

--- a/src/Messaging/MessageBuffer.php
+++ b/src/Messaging/MessageBuffer.php
@@ -72,7 +72,7 @@ class MessageBuffer {
         }
 
         $frameStart = 0;
-        while ($frameStart + 1 <= $dataLen) {
+        while ($frameStart + 2 <= $dataLen) {
             $headerSize     = 2;
             $payload_length = unpack('C', $data[$frameStart + 1] & "\x7f")[1];
             $isMasked       = ($data[$frameStart + 1] & "\x80") === "\x80";

--- a/tests/ab/startServer.php
+++ b/tests/ab/startServer.php
@@ -7,49 +7,60 @@ require_once __DIR__ . "/../bootstrap.php";
 
 $loop   = \React\EventLoop\Factory::create();
 
-$socket = new \React\Socket\Server($loop);
-$server = new \React\Http\Server($socket);
+$socket = new \React\Socket\Server('127.0.0.1:9001', $loop);
 
 $closeFrameChecker = new \Ratchet\RFC6455\Messaging\CloseFrameChecker;
 $negotiator = new \Ratchet\RFC6455\Handshake\ServerNegotiator(new \Ratchet\RFC6455\Handshake\RequestVerifier);
 
 $uException = new \UnderflowException;
 
-$server->on('request', function (\React\Http\Request $request, \React\Http\Response $response) use ($negotiator, $closeFrameChecker, $uException) {
-    $psrRequest = new \GuzzleHttp\Psr7\Request($request->getMethod(), $request->getPath(), $request->getHeaders());
-
-    $negotiatorResponse = $negotiator->handshake($psrRequest);
-
-    $response->writeHead(
-        $negotiatorResponse->getStatusCode(),
-        array_merge(
-            $negotiatorResponse->getHeaders(),
-            ["Content-Length" => "0"]
-        )
-    );
-
-    if ($negotiatorResponse->getStatusCode() !== 101) {
-        $response->end();
-        return;
-    }
-
-    $parser = new \Ratchet\RFC6455\Messaging\MessageBuffer($closeFrameChecker, function(MessageInterface $message) use ($response) {
-        $response->write($message->getContents());
-    }, function(FrameInterface $frame) use ($response, &$parser) {
-        switch ($frame->getOpCode()) {
-            case Frame::OP_CLOSE:
-                $response->end($frame->getContents());
-                break;
-            case Frame::OP_PING:
-                $response->write($parser->newFrame($frame->getPayload(), true, Frame::OP_PONG)->getContents());
-                break;
+$socket->on('connection', function (React\Socket\ConnectionInterface $connection) use ($negotiator, $closeFrameChecker, $uException) {
+    $headerComplete = false;
+    $buffer = '';
+    $parser = null;
+    $connection->on('data', function ($data) use ($connection, &$parser, &$headerComplete, &$buffer, $negotiator, $closeFrameChecker, $uException) {
+        if ($headerComplete) {
+            $parser->onData($data);
+            return;
         }
-    }, true, function() use ($uException) {
-        return $uException;
-    });
 
-    $request->on('data', [$parser, 'onData']);
+        $buffer .= $data;
+        $parts = explode("\r\n\r\n", $buffer);
+        if (count($parts) < 2) {
+            return;
+        }
+        $headerComplete = true;
+        $psrRequest = \GuzzleHttp\Psr7\parse_request($parts[0] . "\r\n\r\n");
+        $negotiatorResponse = $negotiator->handshake($psrRequest);
+
+        $negotiatorResponse = $negotiatorResponse->withAddedHeader("Content-Length", "0");
+
+        $connection->write(\GuzzleHttp\Psr7\str($negotiatorResponse));
+
+        if ($negotiatorResponse->getStatusCode() !== 101) {
+            $connection->end();
+            return;
+        }
+
+        $parser = new \Ratchet\RFC6455\Messaging\MessageBuffer($closeFrameChecker,
+            function (MessageInterface $message) use ($connection) {
+                $connection->write($message->getContents());
+            }, function (FrameInterface $frame) use ($connection, &$parser) {
+                switch ($frame->getOpCode()) {
+                    case Frame::OP_CLOSE:
+                        $connection->end($frame->getContents());
+                        break;
+                    case Frame::OP_PING:
+                        $connection->write($parser->newFrame($frame->getPayload(), true, Frame::OP_PONG)->getContents());
+                        break;
+                }
+            }, true, function () use ($uException) {
+                return $uException;
+            });
+
+        array_shift($parts);
+        $parser->onData(implode("\r\n\r\n", $parts));
+    });
 });
 
-$socket->listen(9001, '0.0.0.0');
 $loop->run();


### PR DESCRIPTION
This drops the development dependency for react/http and bumps react/socket to the latest version.

This change did caused issues with processing lots of small frames during autobahn testing (specifically 9.3.1).

The frame processing has been reworked to peek ahead and figure out the frame sizes and only process the whole frame once it is in the buffer. A large memory copy has also been bypassed making things much faster when dealing with large buffers of small frames.