### PR TITLE
bug fixed: array_intersect([ "protocol1" ], [ "protocol1,subprotocol2" ])

### DIFF
--- a/src/Handshake/ResponseVerifier.php
+++ b/src/Handshake/ResponseVerifier.php
@@ -47,6 +47,24 @@ class ResponseVerifier {
     }
 
     public function verifySubProtocol(array $requestHeader, array $responseHeader) {
+        // [ "protocol1,subprotocol2" ] => [ "protocol1", "subprotocol2" ]
+        $spread = function (array $commaSeparatedHeaders) {
+            $headers = array();
+
+            foreach ($commaSeparatedHeaders as $commaSeparatedHeader) {
+                $headers = array_merge($headers, explode(',', $commaSeparatedHeader));
+            }
+
+            return $headers;
+        };
+
+        if ($requestHeader) {
+            $requestHeader = $spread($requestHeader);
+        }
+        if ($responseHeader) {
+            $responseHeader = $spread($responseHeader);
+        }
+
         return 0 === count($responseHeader) || count(array_intersect($responseHeader, $requestHeader)) > 0;
     }
 }


### PR DESCRIPTION
my nodejs websocket server use these code:
```js

const WebSocket = require('ws');

const wss = new WebSocket.Server({
                                    server : 'localhost',
                                    port   : 8888
                                 }); 

wss.on('connection', function connection(ws) {
    ws.on('message', function incoming(message) {
        ws.send(message); // echo
    }); 
})
```

my php websocket client use these code: 
```php
$reactConnector = new \React\Socket\Connector($loop, [ 'timeout' => 10 ]);
$connector = new \Ratchet\Client\Connector($loop, $reactConnector);
 
$connector('ws://127.0.0.1:8888', ['protocol1',  'subprotocol2'], ['Origin' => 'http://localhost'])
```

but I got a bug on my php code , 
php client code 
```php
// array_intersect([ "protocol1" ], [ "protocol1,subprotocol2" ])  has a bug
array_intersect($responseHeader, $requestHeader);

// array_intersect([ "protocol1" ], [ "protocol1", "subprotocol2" ]) this is what we want
```
 so I make this pull request