### PR TITLE
Ensure max[Message|Frame]PayloadSize is int if auto-set

### DIFF
--- a/src/Messaging/MessageBuffer.php
+++ b/src/Messaging/MessageBuffer.php
@@ -117,10 +117,10 @@ class MessageBuffer {
         $memory_limit_bytes = static::getMemoryLimit();
 
         if ($maxMessagePayloadSize === null) {
-            $maxMessagePayloadSize = $memory_limit_bytes / 4;
+            $maxMessagePayloadSize = intval($memory_limit_bytes / 4);
         }
         if ($maxFramePayloadSize === null) {
-            $maxFramePayloadSize = $memory_limit_bytes / 4;
+            $maxFramePayloadSize = intval($memory_limit_bytes / 4);
         }
 
         if (!is_int($maxFramePayloadSize) || $maxFramePayloadSize > 0x7FFFFFFFFFFFFFFF || $maxFramePayloadSize < 0) { // this should be interesting on non-64 bit systems


### PR DESCRIPTION
fixes #41