### PR TITLE
[0.4] Bump minimum PHP to 7.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,6 @@ jobs:
           - server
         php:
           - 7.4
-          - 7.3
-          - 7.2
-          - 7.1
-          - 7.0
-          - 5.6
     steps:
       - uses: actions/checkout@v2
       - name: Setup PHP
@@ -33,11 +28,4 @@ jobs:
       - run: sh tests/ab/run_ab_tests.sh
         env:
             ABTEST: ${{ matrix.env }}
-            SKIP_DEFLATE: _skip_deflate
-        if: ${{ matrix.php <= 5.6 }}
-
-      - run: sh tests/ab/run_ab_tests.sh
-        env:
-            ABTEST: ${{ matrix.env }}
-        if: ${{ matrix.php >= 7.0 }}
       - run: vendor/bin/phpunit --verbose

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     },
     "require": {
-        "php": ">=5.4.2",
+        "php": ">=7.4",
         "guzzlehttp/psr7": "^2 || ^1.7"
     },
     "require-dev": {


### PR DESCRIPTION
Unblocks #51

Based on https://packagist.org/packages/ratchet/rfc6455/php-stats#0.3 it would cover 75% of active consumers of this library (with PHP 7.2 and 7.3 being another 20% combined).