### PR TITLE
[0.4] Use latest PHPUnit and modernize test code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
           - server
         php:
           - 7.4
+          - 8.0
+          - 8.1
     steps:
       - uses: actions/checkout@v2
       - name: Setup PHP

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.phpunit.result.cache
 composer.lock
 vendor
 tests/ab/reports

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "guzzlehttp/psr7": "^2 || ^1.7"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^9.5",
         "react/socket": "^1.3"
     },
     "scripts": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,27 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
         forceCoversAnnotation="true"
-        mapTestClassNameToCoveredClassName="true"
         bootstrap="tests/bootstrap.php"
         colors="true"
         backupGlobals="false"
         backupStaticAttributes="false"
-        syntaxCheck="false"
         stopOnError="false"
         >
 
     <testsuites>
         <testsuite name="tests">
-            <directory>tests</directory>
-            <exclude>
-                <directory>test/ab</directory>
-            </exclude>
+            <directory>./tests</directory>
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
-            <directory>./src/</directory>
-        </whitelist>
-    </filter>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </coverage>
 </phpunit>

--- a/tests/AbResultsTest.php
+++ b/tests/AbResultsTest.php
@@ -3,10 +3,13 @@
 namespace Ratchet\RFC6455\Test;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @coversNothing
+ */
 class AbResultsTest extends TestCase {
-    private function verifyAutobahnResults($fileName) {
+    private function verifyAutobahnResults(string $fileName): void {
         if (!file_exists($fileName)) {
-            return $this->markTestSkipped('Autobahn TestSuite results not found');
+            $this->markTestSkipped('Autobahn TestSuite results not found');
         }
 
         $resultsJson = file_get_contents($fileName);
@@ -22,11 +25,11 @@ class AbResultsTest extends TestCase {
         }
     }
 
-    public function testAutobahnClientResults() {
+    public function testAutobahnClientResults(): void {
         $this->verifyAutobahnResults(__DIR__ . '/ab/reports/clients/index.json');
     }
 
-    public function testAutobahnServerResults() {
+    public function testAutobahnServerResults(): void {
         $this->verifyAutobahnResults(__DIR__ . '/ab/reports/servers/index.json');
     }
 }

--- a/tests/ab/startServer.php
+++ b/tests/ab/startServer.php
@@ -3,6 +3,9 @@
 use GuzzleHttp\Psr7\Message;
 use GuzzleHttp\Psr7\Response;
 use Ratchet\RFC6455\Handshake\PermessageDeflateOptions;
+use Ratchet\RFC6455\Handshake\RequestVerifier;
+use Ratchet\RFC6455\Handshake\ServerNegotiator;
+use Ratchet\RFC6455\Messaging\CloseFrameChecker;
 use Ratchet\RFC6455\Messaging\MessageBuffer;
 use Ratchet\RFC6455\Messaging\MessageInterface;
 use Ratchet\RFC6455\Messaging\FrameInterface;
@@ -14,17 +17,17 @@ $loop   = \React\EventLoop\Factory::create();
 
 $socket = new \React\Socket\Server('0.0.0.0:9001', $loop);
 
-$closeFrameChecker = new \Ratchet\RFC6455\Messaging\CloseFrameChecker;
-$negotiator = new \Ratchet\RFC6455\Handshake\ServerNegotiator(new \Ratchet\RFC6455\Handshake\RequestVerifier, PermessageDeflateOptions::permessageDeflateSupported());
+$closeFrameChecker = new CloseFrameChecker;
+$negotiator = new ServerNegotiator(new RequestVerifier, PermessageDeflateOptions::permessageDeflateSupported());
 
 $uException = new \UnderflowException;
 
 
-$socket->on('connection', function (React\Socket\ConnectionInterface $connection) use ($negotiator, $closeFrameChecker, $uException, $socket) {
+$socket->on('connection', static function (React\Socket\ConnectionInterface $connection) use ($negotiator, $closeFrameChecker, $uException, $socket): void {
     $headerComplete = false;
     $buffer = '';
     $parser = null;
-    $connection->on('data', function ($data) use ($connection, &$parser, &$headerComplete, &$buffer, $negotiator, $closeFrameChecker, $uException, $socket) {
+    $connection->on('data', static function ($data) use ($connection, &$parser, &$headerComplete, &$buffer, $negotiator, $closeFrameChecker, $uException, $socket): void {
         if ($headerComplete) {
             $parser->onData($data);
             return;
@@ -58,10 +61,10 @@ $socket->on('connection', function (React\Socket\ConnectionInterface $connection
         // we support any valid permessage deflate
         $deflateOptions = PermessageDeflateOptions::fromRequestOrResponse($psrRequest)[0];
 
-        $parser = new \Ratchet\RFC6455\Messaging\MessageBuffer($closeFrameChecker,
-            function (MessageInterface $message, MessageBuffer $messageBuffer) {
+        $parser = new MessageBuffer($closeFrameChecker,
+            static function (MessageInterface $message, MessageBuffer $messageBuffer): void {
                 $messageBuffer->sendMessage($message->getPayload(), true, $message->isBinary());
-            }, function (FrameInterface $frame) use ($connection, &$parser) {
+            }, static function (FrameInterface $frame) use ($connection, &$parser): void {
                 switch ($frame->getOpCode()) {
                     case Frame::OP_CLOSE:
                         $connection->end($frame->getContents());
@@ -70,9 +73,7 @@ $socket->on('connection', function (React\Socket\ConnectionInterface $connection
                         $connection->write($parser->newFrame($frame->getPayload(), true, Frame::OP_PONG)->getContents());
                         break;
                 }
-            }, true, function () use ($uException) {
-                return $uException;
-            },
+            }, true, static fn (): \Exception => $uException,
             null,
             null,
            [$connection, 'write'],

--- a/tests/unit/Handshake/PermessageDeflateOptionsTest.php
+++ b/tests/unit/Handshake/PermessageDeflateOptionsTest.php
@@ -5,9 +5,12 @@ namespace Ratchet\RFC6455\Test\Unit\Handshake;
 use Ratchet\RFC6455\Handshake\PermessageDeflateOptions;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers Ratchet\RFC6455\Handshake\PermessageDeflateOptions
+ */
 class PermessageDeflateOptionsTest extends TestCase
 {
-    public static function versionSupportProvider() {
+    public static function versionSupportProvider(): array {
         return [
             ['7.0.17', false],
             ['7.0.18', true],
@@ -24,7 +27,7 @@ class PermessageDeflateOptionsTest extends TestCase
      * @requires function deflate_init
      * @dataProvider versionSupportProvider
      */
-    public function testVersionSupport($version, $supported) {
+    public function testVersionSupport(string $version, bool $supported): void {
         $this->assertEquals($supported, PermessageDeflateOptions::permessageDeflateSupported($version));
     }
 }

--- a/tests/unit/Handshake/RequestVerifierTest.php
+++ b/tests/unit/Handshake/RequestVerifierTest.php
@@ -14,11 +14,11 @@ class RequestVerifierTest extends TestCase {
      */
     protected $_v;
 
-    public function setUp() {
+    protected function setUp(): void {
         $this->_v = new RequestVerifier();
     }
 
-    public static function methodProvider() {
+    public static function methodProvider(): array {
         return array(
             array(true,  'GET'),
             array(true,  'get'),
@@ -32,11 +32,11 @@ class RequestVerifierTest extends TestCase {
     /**
      * @dataProvider methodProvider
      */
-    public function testMethodMustBeGet($result, $in) {
+    public function testMethodMustBeGet(bool $result, string $in): void {
         $this->assertEquals($result, $this->_v->verifyMethod($in));
     }
 
-    public static function httpVersionProvider() {
+    public static function httpVersionProvider(): array {
         return array(
             array(true,  1.1),
             array(true,  '1.1'),
@@ -56,11 +56,11 @@ class RequestVerifierTest extends TestCase {
     /**
      * @dataProvider httpVersionProvider
      */
-    public function testHttpVersionIsAtLeast1Point1($expected, $in) {
+    public function testHttpVersionIsAtLeast1Point1(bool $expected, $in): void {
         $this->assertEquals($expected, $this->_v->verifyHTTPVersion($in));
     }
 
-    public static function uRIProvider() {
+    public static function uRIProvider(): array {
         return array(
             array(true, '/chat'),
             array(true, '/hello/world?key=val'),
@@ -74,11 +74,11 @@ class RequestVerifierTest extends TestCase {
     /**
      * @dataProvider URIProvider
      */
-    public function testRequestUri($expected, $in) {
+    public function testRequestUri(bool $expected, string $in): void {
         $this->assertEquals($expected, $this->_v->verifyRequestURI($in));
     }
 
-    public static function hostProvider() {
+    public static function hostProvider(): array {
         return array(
             array(true, ['server.example.com']),
             array(false, [])
@@ -88,11 +88,11 @@ class RequestVerifierTest extends TestCase {
     /**
      * @dataProvider HostProvider
      */
-    public function testVerifyHostIsSet($expected, $in) {
+    public function testVerifyHostIsSet(bool $expected, array $in): void {
         $this->assertEquals($expected, $this->_v->verifyHost($in));
     }
 
-    public static function upgradeProvider() {
+    public static function upgradeProvider(): array {
         return array(
             array(true,  ['websocket']),
             array(true,  ['Websocket']),
@@ -105,11 +105,11 @@ class RequestVerifierTest extends TestCase {
     /**
      * @dataProvider upgradeProvider
      */
-    public function testVerifyUpgradeIsWebSocket($expected, $val) {
+    public function testVerifyUpgradeIsWebSocket(bool $expected, array $val): void {
         $this->assertEquals($expected, $this->_v->verifyUpgradeRequest($val));
     }
 
-    public static function connectionProvider() {
+    public static function connectionProvider(): array {
         return array(
             array(true,  ['Upgrade']),
             array(true,  ['upgrade']),
@@ -129,11 +129,11 @@ class RequestVerifierTest extends TestCase {
     /**
      * @dataProvider connectionProvider
      */
-    public function testConnectionHeaderVerification($expected, $val) {
+    public function testConnectionHeaderVerification(bool $expected, array $val): void {
         $this->assertEquals($expected, $this->_v->verifyConnection($val));
     }
 
-    public static function keyProvider() {
+    public static function keyProvider(): array {
         return array(
             array(true,  ['hkfa1L7uwN6DCo4IS3iWAw==']),
             array(true,  ['765vVoQpKSGJwPzJIMM2GA==']),
@@ -154,11 +154,11 @@ class RequestVerifierTest extends TestCase {
     /**
      * @dataProvider keyProvider
      */
-    public function testKeyIsBase64Encoded16BitNonce($expected, $val) {
+    public function testKeyIsBase64Encoded16BitNonce(bool $expected, array $val): void {
         $this->assertEquals($expected, $this->_v->verifyKey($val));
     }
 
-    public static function versionProvider() {
+    public static function versionProvider(): array {
         return array(
             array(true,  [13]),
             array(true,  ['13']),
@@ -174,7 +174,7 @@ class RequestVerifierTest extends TestCase {
     /**
      * @dataProvider versionProvider
      */
-    public function testVersionEquals13($expected, $in) {
+    public function testVersionEquals13(bool $expected, array $in): void {
         $this->assertEquals($expected, $this->_v->verifyVersion($in));
     }
 }

--- a/tests/unit/Handshake/ResponseVerifierTest.php
+++ b/tests/unit/Handshake/ResponseVerifierTest.php
@@ -14,11 +14,11 @@ class ResponseVerifierTest extends TestCase {
      */
     protected $_v;
 
-    public function setUp() {
+    protected function setUp(): void {
         $this->_v = new ResponseVerifier;
     }
 
-    public static function subProtocolsProvider() {
+    public static function subProtocolsProvider(): array {
         return [
             [true,  ['a'], ['a']]
           , [true,  ['c', 'd', 'a'], ['a']]
@@ -33,7 +33,7 @@ class ResponseVerifierTest extends TestCase {
     /**
      * @dataProvider subProtocolsProvider
      */
-    public function testVerifySubProtocol($expected, $request, $response) {
+    public function testVerifySubProtocol(bool $expected, array $request, array $response): void {
         $this->assertEquals($expected, $this->_v->verifySubProtocol($request, $response));
     }
 }

--- a/tests/unit/Handshake/ServerNegotiatorTest.php
+++ b/tests/unit/Handshake/ServerNegotiatorTest.php
@@ -7,9 +7,12 @@ use Ratchet\RFC6455\Handshake\RequestVerifier;
 use Ratchet\RFC6455\Handshake\ServerNegotiator;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers Ratchet\RFC6455\Handshake\ServerNegotiator
+ */
 class ServerNegotiatorTest extends TestCase
 {
-    public function testNoUpgradeRequested() {
+    public function testNoUpgradeRequested(): void {
         $negotiator = new ServerNegotiator(new RequestVerifier());
 
         $requestText = 'GET / HTTP/1.1
@@ -37,7 +40,7 @@ Accept-Language: en-US,en;q=0.8
         $this->assertEquals('13', $response->getHeaderLine('Sec-WebSocket-Version'));
     }
 
-    public function testNoConnectionUpgradeRequested() {
+    public function testNoConnectionUpgradeRequested(): void {
         $negotiator = new ServerNegotiator(new RequestVerifier());
 
         $requestText = 'GET / HTTP/1.1
@@ -63,7 +66,7 @@ Accept-Language: en-US,en;q=0.8
         $this->assertEquals('Connection Upgrade MUST be requested', $response->getReasonPhrase());
     }
 
-    public function testInvalidSecWebsocketKey() {
+    public function testInvalidSecWebsocketKey(): void {
         $negotiator = new ServerNegotiator(new RequestVerifier());
 
         $requestText = 'GET / HTTP/1.1
@@ -90,7 +93,7 @@ Accept-Language: en-US,en;q=0.8
         $this->assertEquals('Invalid Sec-WebSocket-Key', $response->getReasonPhrase());
     }
 
-    public function testInvalidSecWebsocketVersion() {
+    public function testInvalidSecWebsocketVersion(): void {
         $negotiator = new ServerNegotiator(new RequestVerifier());
 
         $requestText = 'GET / HTTP/1.1
@@ -120,7 +123,7 @@ Accept-Language: en-US,en;q=0.8
         $this->assertEquals('13', $response->getHeaderLine('Sec-WebSocket-Version'));
     }
 
-    public function testBadSubprotocolResponse() {
+    public function testBadSubprotocolResponse(): void {
         $negotiator = new ServerNegotiator(new RequestVerifier());
         $negotiator->setStrictSubProtocolCheck(true);
         $negotiator->setSupportedSubProtocols([]);
@@ -154,7 +157,7 @@ Accept-Language: en-US,en;q=0.8
         $this->assertEquals('13', $response->getHeaderLine('Sec-WebSocket-Version'));
     }
 
-    public function testNonStrictSubprotocolDoesNotIncludeHeaderWhenNoneAgreedOn() {
+    public function testNonStrictSubprotocolDoesNotIncludeHeaderWhenNoneAgreedOn(): void {
         $negotiator = new ServerNegotiator(new RequestVerifier());
         $negotiator->setStrictSubProtocolCheck(false);
         $negotiator->setSupportedSubProtocols(['someproto']);
@@ -187,7 +190,7 @@ Accept-Language: en-US,en;q=0.8
         $this->assertFalse($response->hasHeader('Sec-WebSocket-Protocol'));
     }
 
-    public function testSuggestsAppropriateSubprotocol()
+    public function testSuggestsAppropriateSubprotocol(): void
     {
         $negotiator = new ServerNegotiator(new RequestVerifier());
         $negotiator->setStrictSubProtocolCheck(true);

--- a/tests/unit/Messaging/FrameTest.php
+++ b/tests/unit/Messaging/FrameTest.php
@@ -20,7 +20,7 @@ class FrameTest extends TestCase {
 
     protected $_packer;
 
-    public function setUp() {
+    protected function setUp(): void {
         $this->_frame = new Frame;
     }
 
@@ -29,7 +29,7 @@ class FrameTest extends TestCase {
      * @param string of 1's and 0's
      * @return string
      */
-    public static function encode($in) {
+    public static function encode(string $in): string {
         if (strlen($in) > 8) {
             $out = '';
             while (strlen($in) >= 8) {
@@ -46,7 +46,7 @@ class FrameTest extends TestCase {
      * param string The UTF8 message
      * param string The WebSocket framed message, then base64_encoded
      */
-    public static function UnframeMessageProvider() {
+    public static function UnframeMessageProvider(): array {
         return array(
             array('Hello World!', 'gYydAIfa1WXrtvIg0LXvbOP7'),
             array('!@#$%^&*()-=_+[]{}\|/.,<>`~', 'gZv+h96r38f9j9vZ+IHWrvOWoayF9oX6gtfRqfKXwOeg'),
@@ -58,7 +58,7 @@ class FrameTest extends TestCase {
         );
     }
 
-    public static function underflowProvider() {
+    public static function underflowProvider(): array {
         return array(
             array('isFinal', ''),
             array('getRsv1', ''),
@@ -75,19 +75,9 @@ class FrameTest extends TestCase {
 
     /**
      * @dataProvider underflowProvider
-     *
-     * @covers Ratchet\RFC6455\Messaging\Frame::isFinal
-     * @covers Ratchet\RFC6455\Messaging\Frame::getRsv1
-     * @covers Ratchet\RFC6455\Messaging\Frame::getRsv2
-     * @covers Ratchet\RFC6455\Messaging\Frame::getRsv3
-     * @covers Ratchet\RFC6455\Messaging\Frame::getOpcode
-     * @covers Ratchet\RFC6455\Messaging\Frame::isMasked
-     * @covers Ratchet\RFC6455\Messaging\Frame::getPayloadLength
-     * @covers Ratchet\RFC6455\Messaging\Frame::getMaskingKey
-     * @covers Ratchet\RFC6455\Messaging\Frame::getPayload
      */
-    public function testUnderflowExceptionFromAllTheMethodsMimickingBuffering($method, $bin) {
-        $this->setExpectedException('\UnderflowException');
+    public function testUnderflowExceptionFromAllTheMethodsMimickingBuffering(string $method, string $bin): void {
+        $this->expectException(\UnderflowException::class);
         if (!empty($bin)) {
             $this->_frame->addBuffer(static::encode($bin));
         }
@@ -100,7 +90,7 @@ class FrameTest extends TestCase {
      * param int Given, what is the expected opcode
      * param string of 0|1 Each character represents a bit in the byte
      */
-    public static function firstByteProvider() {
+    public static function firstByteProvider(): array {
         return array(
             array(false, false, false, true,   8, '00011000'),
             array(true,  false, true,  false, 10, '10101010'),
@@ -113,20 +103,16 @@ class FrameTest extends TestCase {
 
     /**
      * @dataProvider firstByteProvider
-     * covers Ratchet\RFC6455\Messaging\Frame::isFinal
      */
-    public function testFinCodeFromBits($fin, $rsv1, $rsv2, $rsv3, $opcode, $bin) {
+    public function testFinCodeFromBits(bool $fin, bool $rsv1, bool $rsv2, bool $rsv3, int $opcode, string $bin): void {
         $this->_frame->addBuffer(static::encode($bin));
         $this->assertEquals($fin, $this->_frame->isFinal());
     }
 
     /**
      * @dataProvider firstByteProvider
-     * covers Ratchet\RFC6455\Messaging\Frame::getRsv1
-     * covers Ratchet\RFC6455\Messaging\Frame::getRsv2
-     * covers Ratchet\RFC6455\Messaging\Frame::getRsv3
      */
-    public function testGetRsvFromBits($fin, $rsv1, $rsv2, $rsv3, $opcode, $bin) {
+    public function testGetRsvFromBits(bool $fin, bool $rsv1, bool $rsv2, bool $rsv3, int $opcode, string $bin): void {
         $this->_frame->addBuffer(static::encode($bin));
         $this->assertEquals($rsv1, $this->_frame->getRsv1());
         $this->assertEquals($rsv2, $this->_frame->getRsv2());
@@ -135,32 +121,29 @@ class FrameTest extends TestCase {
 
     /**
      * @dataProvider firstByteProvider
-     * covers Ratchet\RFC6455\Messaging\Frame::getOpcode
      */
-    public function testOpcodeFromBits($fin, $rsv1, $rsv2, $rsv3, $opcode, $bin) {
+    public function testOpcodeFromBits(bool $fin, bool $rsv1, bool $rsv2, bool $rsv3, int $opcode, string $bin): void {
         $this->_frame->addBuffer(static::encode($bin));
         $this->assertEquals($opcode, $this->_frame->getOpcode());
     }
 
     /**
      * @dataProvider UnframeMessageProvider
-     * covers Ratchet\RFC6455\Messaging\Frame::isFinal
      */
-    public function testFinCodeFromFullMessage($msg, $encoded) {
+    public function testFinCodeFromFullMessage(string $msg, string $encoded): void {
         $this->_frame->addBuffer(base64_decode($encoded));
         $this->assertTrue($this->_frame->isFinal());
     }
 
     /**
      * @dataProvider UnframeMessageProvider
-     * covers Ratchet\RFC6455\Messaging\Frame::getOpcode
      */
-    public function testOpcodeFromFullMessage($msg, $encoded) {
+    public function testOpcodeFromFullMessage(string $msg, string $encoded): void {
         $this->_frame->addBuffer(base64_decode($encoded));
         $this->assertEquals(1, $this->_frame->getOpcode());
     }
 
-    public static function payloadLengthDescriptionProvider() {
+    public static function payloadLengthDescriptionProvider(): array {
         return array(
             array(7,  '01110101'),
             array(7,  '01111101'),
@@ -173,10 +156,8 @@ class FrameTest extends TestCase {
 
     /**
      * @dataProvider payloadLengthDescriptionProvider
-     * covers Ratchet\RFC6455\Messaging\Frame::addBuffer
-     * covers Ratchet\RFC6455\Messaging\Frame::getFirstPayloadVal
      */
-    public function testFirstPayloadDesignationValue($bits, $bin) {
+    public function testFirstPayloadDesignationValue(int $bits, string $bin): void {
         $this->_frame->addBuffer(static::encode($this->_firstByteFinText));
         $this->_frame->addBuffer(static::encode($bin));
         $ref = new \ReflectionClass($this->_frame);
@@ -185,22 +166,18 @@ class FrameTest extends TestCase {
         $this->assertEquals(bindec($bin), $cb->invoke($this->_frame));
     }
 
-    /**
-     * covers Ratchet\RFC6455\Messaging\Frame::getFirstPayloadVal
-     */
-    public function testFirstPayloadValUnderflow() {
+    public function testFirstPayloadValUnderflow(): void {
         $ref = new \ReflectionClass($this->_frame);
         $cb  = $ref->getMethod('getFirstPayloadVal');
         $cb->setAccessible(true);
-        $this->setExpectedException('UnderflowException');
+        $this->expectException(\UnderflowException::class);
         $cb->invoke($this->_frame);
     }
 
     /**
      * @dataProvider payloadLengthDescriptionProvider
-     * covers Ratchet\RFC6455\Messaging\Frame::getNumPayloadBits
      */
-    public function testDetermineHowManyBitsAreUsedToDescribePayload($expected_bits, $bin) {
+    public function testDetermineHowManyBitsAreUsedToDescribePayload(int $expected_bits, string $bin): void {
         $this->_frame->addBuffer(static::encode($this->_firstByteFinText));
         $this->_frame->addBuffer(static::encode($bin));
         $ref = new \ReflectionClass($this->_frame);
@@ -209,18 +186,15 @@ class FrameTest extends TestCase {
         $this->assertEquals($expected_bits, $cb->invoke($this->_frame));
     }
 
-    /**
-     * covers Ratchet\RFC6455\Messaging\Frame::getNumPayloadBits
-     */
-    public function testgetNumPayloadBitsUnderflow() {
+    public function testgetNumPayloadBitsUnderflow(): void {
         $ref = new \ReflectionClass($this->_frame);
         $cb  = $ref->getMethod('getNumPayloadBits');
         $cb->setAccessible(true);
-        $this->setExpectedException('UnderflowException');
+        $this->expectException(\UnderflowException::class);
         $cb->invoke($this->_frame);
     }
 
-    public function secondByteProvider() {
+    public function secondByteProvider(): array {
         return array(
             array(true,   1, '10000001'),
             array(false,  1, '00000001'),
@@ -229,9 +203,8 @@ class FrameTest extends TestCase {
     }
     /**
      * @dataProvider secondByteProvider
-     * covers Ratchet\RFC6455\Messaging\Frame::isMasked
      */
-    public function testIsMaskedReturnsExpectedValue($masked, $payload_length, $bin) {
+    public function testIsMaskedReturnsExpectedValue(bool $masked, int $payload_length, string $bin): void {
         $this->_frame->addBuffer(static::encode($this->_firstByteFinText));
         $this->_frame->addBuffer(static::encode($bin));
         $this->assertEquals($masked, $this->_frame->isMasked());
@@ -239,18 +212,16 @@ class FrameTest extends TestCase {
 
     /**
      * @dataProvider UnframeMessageProvider
-     * covers Ratchet\RFC6455\Messaging\Frame::isMasked
      */
-    public function testIsMaskedFromFullMessage($msg, $encoded) {
+    public function testIsMaskedFromFullMessage(string $msg, string $encoded): void {
         $this->_frame->addBuffer(base64_decode($encoded));
         $this->assertTrue($this->_frame->isMasked());
     }
 
     /**
      * @dataProvider secondByteProvider
-     * covers Ratchet\RFC6455\Messaging\Frame::getPayloadLength
      */
-    public function testGetPayloadLengthWhenOnlyFirstFrameIsUsed($masked, $payload_length, $bin) {
+    public function testGetPayloadLengthWhenOnlyFirstFrameIsUsed(bool $masked, int $payload_length, string $bin): void {
         $this->_frame->addBuffer(static::encode($this->_firstByteFinText));
         $this->_frame->addBuffer(static::encode($bin));
         $this->assertEquals($payload_length, $this->_frame->getPayloadLength());
@@ -258,15 +229,14 @@ class FrameTest extends TestCase {
 
     /**
      * @dataProvider UnframeMessageProvider
-     * covers Ratchet\RFC6455\Messaging\Frame::getPayloadLength
      * @todo Not yet testing when second additional payload length descriptor
      */
-    public function testGetPayloadLengthFromFullMessage($msg, $encoded) {
+    public function testGetPayloadLengthFromFullMessage(string $msg, string $encoded): void {
         $this->_frame->addBuffer(base64_decode($encoded));
         $this->assertEquals(strlen($msg), $this->_frame->getPayloadLength());
     }
 
-    public function maskingKeyProvider() {
+    public function maskingKeyProvider(): array {
         $frame = new Frame;
         return array(
             array($frame->generateMaskingKey()),
@@ -277,35 +247,30 @@ class FrameTest extends TestCase {
 
     /**
      * @dataProvider maskingKeyProvider
-     * covers Ratchet\RFC6455\Messaging\Frame::getMaskingKey
      * @todo I I wrote the dataProvider incorrectly, skipping for now
      */
-    public function testGetMaskingKey($mask) {
+    public function testGetMaskingKey(string $mask): void {
         $this->_frame->addBuffer(static::encode($this->_firstByteFinText));
         $this->_frame->addBuffer(static::encode($this->_secondByteMaskedSPL));
         $this->_frame->addBuffer($mask);
         $this->assertEquals($mask, $this->_frame->getMaskingKey());
     }
 
-    /**
-     * covers Ratchet\RFC6455\Messaging\Frame::getMaskingKey
-     */
-    public function testGetMaskingKeyOnUnmaskedPayload() {
+    public function testGetMaskingKeyOnUnmaskedPayload(): void {
         $frame = new Frame('Hello World!');
         $this->assertEquals('', $frame->getMaskingKey());
     }
 
     /**
      * @dataProvider UnframeMessageProvider
-     * covers Ratchet\RFC6455\Messaging\Frame::getPayload
      * @todo Move this test to bottom as it requires all methods of the class
      */
-    public function testUnframeFullMessage($unframed, $base_framed) {
+    public function testUnframeFullMessage(string $unframed, string $base_framed): void {
         $this->_frame->addBuffer(base64_decode($base_framed));
         $this->assertEquals($unframed, $this->_frame->getPayload());
     }
 
-    public static function messageFragmentProvider() {
+    public static function messageFragmentProvider(): array {
         return array(
             array(false, '', '', '', '', '')
         );
@@ -313,9 +278,8 @@ class FrameTest extends TestCase {
 
     /**
      * @dataProvider UnframeMessageProvider
-     * covers Ratchet\RFC6455\Messaging\Frame::getPayload
      */
-    public function testCheckPiecingTogetherMessage($msg, $encoded) {
+    public function testCheckPiecingTogetherMessage(string $msg, string $encoded): void {
         $framed = base64_decode($encoded);
         for ($i = 0, $len = strlen($framed);$i < $len; $i++) {
             $this->_frame->addBuffer(substr($framed, $i, 1));
@@ -323,12 +287,7 @@ class FrameTest extends TestCase {
         $this->assertEquals($msg, $this->_frame->getPayload());
     }
 
-    /**
-     * covers Ratchet\RFC6455\Messaging\Frame::__construct
-     * covers Ratchet\RFC6455\Messaging\Frame::getPayloadLength
-     * covers Ratchet\RFC6455\Messaging\Frame::getPayload
-     */
-    public function testLongCreate() {
+    public function testLongCreate(): void {
         $len = 65525;
         $pl  = $this->generateRandomString($len);
         $frame = new Frame($pl, true, Frame::OP_PING);
@@ -339,20 +298,13 @@ class FrameTest extends TestCase {
         $this->assertEquals($pl, $frame->getPayload());
     }
 
-    /**
-     * covers Ratchet\RFC6455\Messaging\Frame::__construct
-     * covers Ratchet\RFC6455\Messaging\Frame::getPayloadLength
-     */
-    public function testReallyLongCreate() {
+    public function testReallyLongCreate(): void {
         $len = 65575;
         $frame = new Frame($this->generateRandomString($len));
         $this->assertEquals($len, $frame->getPayloadLength());
     }
-    /**
-     * covers Ratchet\RFC6455\Messaging\Frame::__construct
-     * covers Ratchet\RFC6455\Messaging\Frame::extractOverflow
-     */
-    public function testExtractOverflow() {
+
+    public function testExtractOverflow(): void {
         $string1 = $this->generateRandomString();
         $frame1  = new Frame($string1);
         $string2 = $this->generateRandomString();
@@ -367,10 +319,7 @@ class FrameTest extends TestCase {
         $this->assertEquals($string2, $uncat->getPayload());
     }
 
-    /**
-     * covers Ratchet\RFC6455\Messaging\Frame::extractOverflow
-     */
-    public function testEmptyExtractOverflow() {
+    public function testEmptyExtractOverflow(): void {
         $string = $this->generateRandomString();
         $frame  = new Frame($string);
         $this->assertEquals($string, $frame->getPayload());
@@ -378,10 +327,7 @@ class FrameTest extends TestCase {
         $this->assertEquals($string, $frame->getPayload());
     }
 
-    /**
-     * covers Ratchet\RFC6455\Messaging\Frame::getContents
-     */
-    public function testGetContents() {
+    public function testGetContents(): void {
         $msg = 'The quick brown fox jumps over the lazy dog.';
         $frame1 = new Frame($msg);
         $frame2 = new Frame($msg);
@@ -390,10 +336,7 @@ class FrameTest extends TestCase {
         $this->assertEquals(strlen($frame1->getContents()) + 4, strlen($frame2->getContents()));
     }
 
-    /**
-     * covers Ratchet\RFC6455\Messaging\Frame::maskPayload
-     */
-    public function testMasking() {
+    public function testMasking(): void {
         $msg   = 'The quick brown fox jumps over the lazy dog.';
         $frame = new Frame($msg);
         $frame->maskPayload();
@@ -401,10 +344,7 @@ class FrameTest extends TestCase {
         $this->assertEquals($msg, $frame->getPayload());
     }
 
-    /**
-     * covers Ratchet\RFC6455\Messaging\Frame::unMaskPayload
-     */
-    public function testUnMaskPayload() {
+    public function testUnMaskPayload(): void {
         $string = $this->generateRandomString();
         $frame  = new Frame($string);
         $frame->maskPayload()->unMaskPayload();
@@ -412,10 +352,7 @@ class FrameTest extends TestCase {
         $this->assertEquals($string, $frame->getPayload());
     }
 
-    /**
-     * covers Ratchet\RFC6455\Messaging\Frame::generateMaskingKey
-     */
-    public function testGenerateMaskingKey() {
+    public function testGenerateMaskingKey(): void {
         $dupe = false;
         $done = array();
         for ($i = 0; $i < 10; $i++) {
@@ -429,27 +366,20 @@ class FrameTest extends TestCase {
         $this->assertFalse($dupe);
     }
 
-    /**
-     * covers Ratchet\RFC6455\Messaging\Frame::maskPayload
-     */
-    public function testGivenMaskIsValid() {
-        $this->setExpectedException('InvalidArgumentException');
+    public function testGivenMaskIsValid(): void {
+        $this->expectException(\InvalidArgumentException::class);
         $this->_frame->maskPayload('hello world');
     }
 
     /**
-     * covers Ratchet\RFC6455\Messaging\Frame::maskPayload
+     * @requires extension mbstring
      */
-    public function testGivenMaskIsValidAscii() {
-        if (!extension_loaded('mbstring')) {
-            $this->markTestSkipped("mbstring required for this test");
-            return;
-        }
-        $this->setExpectedException('OutOfBoundsException');
+    public function testGivenMaskIsValidAscii(): void {
+        $this->expectException(\OutOfBoundsException::class);
         $this->_frame->maskPayload('x✖');
     }
 
-    protected function generateRandomString($length = 10, $addSpaces = true, $addNumbers = true) {
+    protected function generateRandomString(int $length = 10, bool $addSpaces = true, bool $addNumbers = true): string {
         $characters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!"$%&/()=[]{}'; // ยง
         $useChars = array();
         for($i = 0; $i < $length; $i++) {
@@ -473,11 +403,8 @@ class FrameTest extends TestCase {
      * to set the payload length to 126 and then not recalculate it once the full length information was available.
      *
      * This is fixed by setting the defPayLen back to -1 before the underflow exception is thrown.
-     *
-     * covers Ratchet\RFC6455\Messaging\Frame::getPayloadLength
-     * covers Ratchet\RFC6455\Messaging\Frame::extractOverflow
      */
-    public function testFrameDeliveredOneByteAtATime() {
+    public function testFrameDeliveredOneByteAtATime(): void {
         $startHeader = "\x01\x7e\x01\x00"; // header for a text frame of 256 - non-final
         $framePayload = str_repeat("*", 256);
         $rawOverflow = "xyz";

--- a/tests/unit/Messaging/MessageBufferTest.php
+++ b/tests/unit/Messaging/MessageBufferTest.php
@@ -9,13 +9,16 @@ use Ratchet\RFC6455\Messaging\MessageBuffer;
 use React\EventLoop\Factory;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers Ratchet\RFC6455\Messaging\MessageBuffer
+ */
 class MessageBufferTest extends TestCase
 {
     /**
      * This is to test that MessageBuffer can handle a large receive
      * buffer with many many frames without blowing the stack (pre-v0.4 issue)
      */
-    public function testProcessingLotsOfFramesInASingleChunk() {
+    public function testProcessingLotsOfFramesInASingleChunk(): void {
         $frame = new Frame('a', true, Frame::OP_TEXT);
 
         $frameRaw = $frame->getContents();
@@ -26,7 +29,7 @@ class MessageBufferTest extends TestCase
 
         $messageBuffer = new MessageBuffer(
             new CloseFrameChecker(),
-            function (Message $message) use (&$messageCount) {
+            function (Message $message) use (&$messageCount): void {
                 $messageCount++;
                 $this->assertEquals('a', $message->getPayload());
             },
@@ -39,7 +42,7 @@ class MessageBufferTest extends TestCase
         $this->assertEquals(1000, $messageCount);
     }
 
-    public function testProcessingMessagesAsynchronouslyWhileBlockingInMessageHandler() {
+    public function testProcessingMessagesAsynchronouslyWhileBlockingInMessageHandler(): void {
         $loop = Factory::create();
 
         $frameA = new Frame('a', true, Frame::OP_TEXT);
@@ -49,7 +52,7 @@ class MessageBufferTest extends TestCase
 
         $messageBuffer = new MessageBuffer(
             new CloseFrameChecker(),
-            function (Message $message) use (&$messageCount, &$bReceived, $loop) {
+            static function (Message $message) use (&$messageCount, &$bReceived, $loop): void {
                 $payload = $message->getPayload();
                 $bReceived = $payload === 'b';
 
@@ -61,7 +64,7 @@ class MessageBufferTest extends TestCase
             false
         );
 
-        $loop->addPeriodicTimer(0.1, function () use ($messageBuffer, $frameB, $loop) {
+        $loop->addPeriodicTimer(0.1, static function () use ($messageBuffer, $frameB, $loop): void {
             $loop->stop();
             $messageBuffer->onData($frameB->getContents());
         });
@@ -71,7 +74,7 @@ class MessageBufferTest extends TestCase
         $this->assertTrue($bReceived);
     }
 
-    public function testInvalidFrameLength() {
+    public function testInvalidFrameLength(): void {
         $frame = new Frame(str_repeat('a', 200), true, Frame::OP_TEXT);
 
         $frameRaw = $frame->getContents();
@@ -93,7 +96,7 @@ class MessageBufferTest extends TestCase
 
         $messageBuffer = new MessageBuffer(
             new CloseFrameChecker(),
-            function (Message $message) use (&$messageCount) {
+            static function (Message $message) use (&$messageCount): void {
                 $messageCount++;
             },
             function (Frame $frame) use (&$controlFrame) {
@@ -109,13 +112,13 @@ class MessageBufferTest extends TestCase
         $messageBuffer->onData($frameRaw);
 
         $this->assertEquals(0, $messageCount);
-        $this->assertTrue($controlFrame instanceof Frame);
+        $this->assertInstanceOf(Frame::class, $controlFrame);
         $this->assertEquals(Frame::OP_CLOSE, $controlFrame->getOpcode());
         $this->assertEquals([Frame::CLOSE_PROTOCOL], array_merge(unpack('n*', substr($controlFrame->getPayload(), 0, 2))));
 
     }
 
-    public function testFrameLengthTooBig() {
+    public function testFrameLengthTooBig(): void {
         $frame = new Frame(str_repeat('a', 200), true, Frame::OP_TEXT);
 
         $frameRaw = $frame->getContents();
@@ -137,10 +140,10 @@ class MessageBufferTest extends TestCase
 
         $messageBuffer = new MessageBuffer(
             new CloseFrameChecker(),
-            function (Message $message) use (&$messageCount) {
+            static function (Message $message) use (&$messageCount): void {
                 $messageCount++;
             },
-            function (Frame $frame) use (&$controlFrame) {
+            function (Frame $frame) use (&$controlFrame): void {
                 $this->assertNull($controlFrame);
                 $controlFrame = $frame;
             },
@@ -153,12 +156,12 @@ class MessageBufferTest extends TestCase
         $messageBuffer->onData($frameRaw);
 
         $this->assertEquals(0, $messageCount);
-        $this->assertTrue($controlFrame instanceof Frame);
+        $this->assertInstanceOf(Frame::class, $controlFrame);
         $this->assertEquals(Frame::OP_CLOSE, $controlFrame->getOpcode());
         $this->assertEquals([Frame::CLOSE_TOO_BIG], array_merge(unpack('n*', substr($controlFrame->getPayload(), 0, 2))));
     }
 
-    public function testFrameLengthBiggerThanMaxMessagePayload() {
+    public function testFrameLengthBiggerThanMaxMessagePayload(): void {
         $frame = new Frame(str_repeat('a', 200), true, Frame::OP_TEXT);
 
         $frameRaw = $frame->getContents();
@@ -169,10 +172,10 @@ class MessageBufferTest extends TestCase
 
         $messageBuffer = new MessageBuffer(
             new CloseFrameChecker(),
-            function (Message $message) use (&$messageCount) {
+            static function (Message $message) use (&$messageCount): void {
                 $messageCount++;
             },
-            function (Frame $frame) use (&$controlFrame) {
+            function (Frame $frame) use (&$controlFrame): void {
                 $this->assertNull($controlFrame);
                 $controlFrame = $frame;
             },
@@ -185,12 +188,12 @@ class MessageBufferTest extends TestCase
         $messageBuffer->onData($frameRaw);
 
         $this->assertEquals(0, $messageCount);
-        $this->assertTrue($controlFrame instanceof Frame);
+        $this->assertInstanceOf(Frame::class, $controlFrame);
         $this->assertEquals(Frame::OP_CLOSE, $controlFrame->getOpcode());
         $this->assertEquals([Frame::CLOSE_TOO_BIG], array_merge(unpack('n*', substr($controlFrame->getPayload(), 0, 2))));
     }
 
-    public function testSecondFrameLengthPushesPastMaxMessagePayload() {
+    public function testSecondFrameLengthPushesPastMaxMessagePayload(): void {
         $frame = new Frame(str_repeat('a', 200), false, Frame::OP_TEXT);
         $firstFrameRaw = $frame->getContents();
         $frame = new Frame(str_repeat('b', 200), true, Frame::OP_TEXT);
@@ -202,10 +205,10 @@ class MessageBufferTest extends TestCase
 
         $messageBuffer = new MessageBuffer(
             new CloseFrameChecker(),
-            function (Message $message) use (&$messageCount) {
+            static function (Message $message) use (&$messageCount): void {
                 $messageCount++;
             },
-            function (Frame $frame) use (&$controlFrame) {
+            function (Frame $frame) use (&$controlFrame): void {
                 $this->assertNull($controlFrame);
                 $controlFrame = $frame;
             },
@@ -220,7 +223,7 @@ class MessageBufferTest extends TestCase
         $messageBuffer->onData(substr($secondFrameRaw, 0, 150));
 
         $this->assertEquals(0, $messageCount);
-        $this->assertTrue($controlFrame instanceof Frame);
+        $this->assertInstanceOf(Frame::class, $controlFrame);
         $this->assertEquals(Frame::OP_CLOSE, $controlFrame->getOpcode());
         $this->assertEquals([Frame::CLOSE_TOO_BIG], array_merge(unpack('n*', substr($controlFrame->getPayload(), 0, 2))));
     }
@@ -258,15 +261,15 @@ class MessageBufferTest extends TestCase
      * @param string $phpConfigurationValue
      * @param int $expectedLimit
      */
-    public function testMemoryLimits($phpConfigurationValue, $expectedLimit) {
-        $method = new \ReflectionMethod('Ratchet\RFC6455\Messaging\MessageBuffer', 'getMemoryLimit');
+    public function testMemoryLimits(string $phpConfigurationValue, int $expectedLimit): void {
+        $method = new \ReflectionMethod(MessageBuffer::class, 'getMemoryLimit');
         $method->setAccessible(true);
         $actualLimit = $method->invoke(null, $phpConfigurationValue);
 
         $this->assertSame($expectedLimit, $actualLimit);
     }
 
-    public function phpConfigurationProvider() {
+    public function phpConfigurationProvider(): array {
         return [
             'without unit type, just bytes' => ['500', 500],
             '1 GB with big "G"' => ['1G', 1 * 1024 * 1024 * 1024],
@@ -281,14 +284,13 @@ class MessageBufferTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testInvalidMaxFramePayloadSizes() {
-        $messageBuffer = new MessageBuffer(
+    public function testInvalidMaxFramePayloadSizes(): void {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new MessageBuffer(
             new CloseFrameChecker(),
-            function (Message $message) {},
-            function (Frame $frame) {},
+            static function (Message $message): void {},
+            static function (Frame $frame): void {},
             false,
             null,
             0,
@@ -296,14 +298,13 @@ class MessageBufferTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testInvalidMaxMessagePayloadSizes() {
-        $messageBuffer = new MessageBuffer(
+    public function testInvalidMaxMessagePayloadSizes(): void {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new MessageBuffer(
             new CloseFrameChecker(),
-            function (Message $message) {},
-            function (Frame $frame) {},
+            static function (Message $message): void {},
+            static function (Frame $frame): void {},
             false,
             null,
             0x8000000000000000,
@@ -318,9 +319,8 @@ class MessageBufferTest extends TestCase
      * @param int $expectedLimit
      *
      * @runInSeparateProcess
-     * @requires PHP 7.0
      */
-    public function testIniSizes($phpConfigurationValue, $expectedLimit) {
+    public function testIniSizes(string $phpConfigurationValue, int $expectedLimit): void {
         $value = @ini_set('memory_limit', $phpConfigurationValue);
         if ($value === false) {
            $this->markTestSkipped("Does not support setting the memory_limit lower than current memory_usage");
@@ -328,8 +328,8 @@ class MessageBufferTest extends TestCase
 
         $messageBuffer = new MessageBuffer(
             new CloseFrameChecker(),
-            function (Message $message) {},
-            function (Frame $frame) {},
+            static function (Message $message): void {},
+            static function (Frame $frame): void {},
             false,
             null
         );
@@ -349,9 +349,8 @@ class MessageBufferTest extends TestCase
 
     /**
      * @runInSeparateProcess
-     * @requires PHP 7.0
      */
-    public function testInvalidIniSize() {
+    public function testInvalidIniSize(): void {
         $value = @ini_set('memory_limit', 'lots of memory');
         if ($value === false) {
             $this->markTestSkipped("Does not support setting the memory_limit lower than current memory_usage");

--- a/tests/unit/Messaging/MessageTest.php
+++ b/tests/unit/Messaging/MessageTest.php
@@ -13,20 +13,20 @@ class MessageTest extends TestCase {
     /** @var Message */
     protected $message;
 
-    public function setUp() {
+    protected function setUp(): void {
         $this->message = new Message;
     }
 
-    public function testNoFrames() {
+    public function testNoFrames(): void {
         $this->assertFalse($this->message->isCoalesced());
     }
 
-    public function testNoFramesOpCode() {
-        $this->setExpectedException('UnderflowException');
+    public function testNoFramesOpCode(): void {
+        $this->expectException(\UnderflowException::class);
         $this->message->getOpCode();
     }
 
-    public function testFragmentationPayload() {
+    public function testFragmentationPayload(): void {
         $a = 'Hello ';
         $b = 'World!';
         $f1 = new Frame($a, false);
@@ -36,13 +36,13 @@ class MessageTest extends TestCase {
         $this->assertEquals($a . $b, $this->message->getPayload());
     }
 
-    public function testUnbufferedFragment() {
+    public function testUnbufferedFragment(): void {
         $this->message->addFrame(new Frame('The quick brow', false));
-        $this->setExpectedException('UnderflowException');
+        $this->expectException(\UnderflowException::class);
         $this->message->getPayload();
     }
 
-    public function testGetOpCode() {
+    public function testGetOpCode(): void {
         $this->message
             ->addFrame(new Frame('The quick brow', false, Frame::OP_TEXT))
             ->addFrame(new Frame('n fox jumps ov', false, Frame::OP_CONTINUE))
@@ -51,7 +51,7 @@ class MessageTest extends TestCase {
         $this->assertEquals(Frame::OP_TEXT, $this->message->getOpCode());
     }
 
-    public function testGetUnBufferedPayloadLength() {
+    public function testGetUnBufferedPayloadLength(): void {
         $this->message
             ->addFrame(new Frame('The quick brow', false, Frame::OP_TEXT))
             ->addFrame(new Frame('n fox jumps ov', false, Frame::OP_CONTINUE))


### PR DESCRIPTION
Closes #58

- Bumps the PHPUnit requirement to 9.5
- Adds CI for PHP 8 and 8.1
- Modernizes test code (updated PHPUnit config, updates PHPUnit usage to account for deprecations/removals, starts adding typehints, and misc. code structure tweaks)