### PR TITLE
Handle up to 2GB payload on PHP32bits

### DIFF
--- a/src/Messaging/MessageBuffer.php
+++ b/src/Messaging/MessageBuffer.php
@@ -158,10 +158,12 @@ class MessageBuffer {
                 $payloadLenBytes = $payload_length === 126 ? 2 : 8;
                 $headerSize      += $payloadLenBytes;
                 $bytesToUpack    = substr($data, $frameStart + 2, $payloadLenBytes);
+                $payloadLenOver2GB = false
 
                 if ($payload_length === 126){
                     $payload_length = unpack('n', $bytesToUpack)[1];
                 } else {
+                    $payloadLenOver2GB = unpack('N', $bytesToUpack)[1] > 0; //Decode only the 4 first bytes
                     if (PHP_INT_SIZE == 4) { // if 32bits PHP
                         $bytesToUpack = substr($bytesToUpack, 4); //Keep only 4 last bytes
                         $payload_length = unpack('N', $bytesToUpack)[1];
@@ -176,6 +178,10 @@ class MessageBuffer {
             if ($payload_length < 0) {
                 // this can happen when unpacking in php
                 $closeFrame = $this->newCloseFrame(Frame::CLOSE_PROTOCOL, 'Invalid frame length');
+            }
+
+            if (!$closeFrame && PHP_INT_SIZE == 4 && $payloadLenOver2GB) {
+                $closeFrame = $this->newCloseFrame(Frame::CLOSE_TOO_BIG, 'Frame over 2GB can\'t be handled on 32bits PHP');
             }
 
             if (!$closeFrame && $this->maxFramePayloadSize > 1 && $payload_length > $this->maxFramePayloadSize) {

--- a/src/Messaging/MessageBuffer.php
+++ b/src/Messaging/MessageBuffer.php
@@ -158,7 +158,7 @@ class MessageBuffer {
                 $payloadLenBytes = $payload_length === 126 ? 2 : 8;
                 $headerSize      += $payloadLenBytes;
                 $bytesToUpack    = substr($data, $frameStart + 2, $payloadLenBytes);
-                $payloadLenOver2GB = false
+                $payloadLenOver2GB = false;
 
                 if ($payload_length === 126){
                     $payload_length = unpack('n', $bytesToUpack)[1];

--- a/src/Messaging/MessageBuffer.php
+++ b/src/Messaging/MessageBuffer.php
@@ -158,9 +158,17 @@ class MessageBuffer {
                 $payloadLenBytes = $payload_length === 126 ? 2 : 8;
                 $headerSize      += $payloadLenBytes;
                 $bytesToUpack    = substr($data, $frameStart + 2, $payloadLenBytes);
-                $payload_length  = $payload_length === 126
-                    ? unpack('n', $bytesToUpack)[1]
-                    : unpack('J', $bytesToUpack)[1];
+
+                if ($payload_length === 126){
+                    $payload_length = unpack('n', $bytesToUpack)[1];
+                } else {
+                    if (PHP_INT_SIZE == 4) { // if 32bits PHP
+                        $bytesToUpack = substr($bytesToUpack, 4); //Keep only 4 last bytes
+                        $payload_length = unpack('N', $bytesToUpack)[1];
+                    } else {
+                        $payload_length = unpack('J', $bytesToUpack)[1];
+                    }
+                }
             }
 
             $closeFrame = null;


### PR DESCRIPTION
PR described in issue https://github.com/ratchetphp/RFC6455/issues/64

Main idea is to avoid `unpack('J',...` on 32bits system.

$payload_length is in Big Endian allowing to keep only 4 last bytes to unpack it as an `unsigned long` instead of `unsigned long long`