### PR TITLE
Fix to provide php v8.1 compatibility

### DIFF
--- a/src/Messaging/Message.php
+++ b/src/Messaging/Message.php
@@ -27,7 +27,7 @@ class Message implements \IteratorAggregate, MessageInterface {
      * {@inheritdoc}
      */
     #[\ReturnTypeWillChange]
-    public function count() {
+    public function count(): int {
         return count($this->_frames);
     }
 

--- a/src/Messaging/Message.php
+++ b/src/Messaging/Message.php
@@ -1,6 +1,5 @@
 <?php
 namespace Ratchet\RFC6455\Messaging;
-use Traversable;
 
 class Message implements \IteratorAggregate, MessageInterface {
     /**
@@ -20,7 +19,7 @@ class Message implements \IteratorAggregate, MessageInterface {
     }
 
     #[\ReturnTypeWillChange]
-    public function getIterator(): Traversable {
+    public function getIterator(): \Traversable {
         return $this->_frames;
     }
 

--- a/src/Messaging/Message.php
+++ b/src/Messaging/Message.php
@@ -19,7 +19,7 @@ class Message implements \IteratorAggregate, MessageInterface {
     }
 
     #[\ReturnTypeWillChange]
-    public function getIterator() {
+    public function getIterator(): Traversable {
         return $this->_frames;
     }
 

--- a/src/Messaging/Message.php
+++ b/src/Messaging/Message.php
@@ -1,5 +1,6 @@
 <?php
 namespace Ratchet\RFC6455\Messaging;
+use Traversable;
 
 class Message implements \IteratorAggregate, MessageInterface {
     /**


### PR DESCRIPTION
Provided: Avoid deprecation User Deprecated: Method "Countable::count()" might add "int" as a native return type declaration in the future. Do the same in implementation "Ratchet\RFC6455\Messaging\Message" now to avoid errors or add an explicit @return annotation to suppress this message.