### PR TITLE
PHP 8.4: Implicitly nullable parameters deprecated

### DIFF
--- a/src/Handshake/ClientNegotiator.php
+++ b/src/Handshake/ClientNegotiator.php
@@ -16,7 +16,7 @@ class ClientNegotiator {
      */
     private $defaultHeader;
 
-    function __construct(PermessageDeflateOptions $perMessageDeflateOptions = null) {
+    function __construct(?PermessageDeflateOptions $perMessageDeflateOptions = null) {
         $this->verifier = new ResponseVerifier;
 
         $this->defaultHeader = new Request('GET', '', [


### PR DESCRIPTION
Implicitly marking parameter $perMessageDeflateOptions as nullable is deprecated, the explicit nullable type must be used instead.